### PR TITLE
Some minor bpaf fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 !Cargo.lock
+/target

--- a/crates/elp/src/bin/args.rs
+++ b/crates/elp/src/bin/args.rs
@@ -383,19 +383,13 @@ pub fn command() -> impl Parser<Command> {
 fn parse_print_diags() -> impl Parser<bool> {
     long("no-diags")
         .help("Do not print the full diagnostics for a file, just the count")
-        .switch()
-        .map(|v| {
-            !v // negate
-        })
+        .flag(/* present */ false, true)
 }
 
 fn parse_experimental_diags() -> impl Parser<bool> {
     long("experimental")
         .help("Report experimental diagnostics too, if diagnostics are enabled")
-        .switch()
-        .map(|v| {
-            !v // negate
-        })
+        .flag(/* present */ false, true)
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
- elp::args - use flag instead of switch + negate combo
- add /target to .gitignore

### Describe your changes

minor improvements to bpaf code, it should be possible to clean it up more with 0.9 branch - show help by default, etc.

----

`--experimental` flag seems a bit strange. Name and help suggest that it will enable experimental diagnostics, while value it produces and how it is later used suggests that experimental diagnostics will be disabled:


```
crates/elp/src/bin/elp_parse_cli.rs:    cfg.disable_experimental = args.experimental_diags;
crates/elp/src/bin/lint_cli.rs:            cfg.disable_experimental = args.experimental_diags;
```