### PR TITLE
Use alternate logo for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Erlang Language Platform (ELP)
 
-![ELP](logo/elp_final_Full_Logo_Color.png "ELP Logo")
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./logo/elp_final_Full_Logo_White_Text.png">
+  <img alt="ELP logo" src="./logo/elp_final_Full_Logo_Color.png" width="100%">
+</picture>
 
 ## Description
 


### PR DESCRIPTION
Summary: In the README, detect dark mode and use the white-text logo instead.

Differential Revision: D48111981

