### PR TITLE
Fix OSS build

### DIFF
--- a/crates/ide/src/diagnostics/application_env.rs
+++ b/crates/ide/src/diagnostics/application_env.rs
@@ -63,7 +63,7 @@ pub(crate) enum BadEnvCallAction {
     /// The `tag` must match, and we check the `index`th part of the
     /// second tuple element
     /// e.g. `our_mod:a_fun(Context, Location, [..., {cfg, {Application, Flag}}, ...], Format, Args)
-    // @oss-only #[allow(dead_code)]
+    #[allow(dead_code)] // @oss-only
     OptionsArg {
         /// Which argument contains the list of options to be checked
         arg_index: usize,

--- a/crates/ide/src/diagnostics/deprecated_function.rs
+++ b/crates/ide/src/diagnostics/deprecated_function.rs
@@ -46,7 +46,7 @@ pub struct DeprecationDetails {
     message: Option<String>,
 }
 
-// @oss-only #[allow(dead_code)]
+#[allow(dead_code)] // @oss-only
 impl DeprecationDetails {
     pub fn new() -> Self {
         DeprecationDetails {

--- a/crates/ide/src/diagnostics/replace_call.rs
+++ b/crates/ide/src/diagnostics/replace_call.rs
@@ -104,6 +104,7 @@ pub fn replace_call_site_if_args_match(
         });
 }
 
+#[allow(dead_code)] // @oss-only
 pub fn adhoc_diagnostic(mfa: &MFA, extra_info: &str, range: TextRange) -> Option<Diagnostic> {
     let mfa_str = mfa.label();
     let sep = if extra_info.is_empty() { "" } else { " " };


### PR DESCRIPTION
Summary: The `oss-only` tags need a `:` on the meta internal side.

Differential Revision: D49369594


