### PR TITLE
Set both include_dirs and include_path for rebar3 deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,6 +2117,8 @@ dependencies = [
 [[package]]
 name = "tree-sitter-erlang"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e812f0b7cf3ee07049dd4433c420dec32e421467084456fcd4c6151bf6817b07"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/project_model/src/rebar.rs
+++ b/crates/project_model/src/rebar.rs
@@ -171,6 +171,10 @@ impl RebarProject {
                 .map(|term| Ok(to_string(term)?.to_owned()))
                 .collect::<Result<_>>()?;
             let abs_src_dirs: Vec<AbsPathBuf> = src_dirs.iter().map(|src| dir.join(src)).collect();
+            let include_dirs: Vec<AbsPathBuf> = to_vec(map_get(term, "include_dirs")?)?
+                .iter()
+                .map(to_abs_path)
+                .collect::<Result<_>>()?;
             Ok(ProjectAppData {
                 name: AppName(to_string(map_get(term, "name")?)?.to_string()),
                 dir,
@@ -179,14 +183,11 @@ impl RebarProject {
                     .iter()
                     .map(|term| Ok(to_string(term)?.to_owned()))
                     .collect::<Result<_>>()?,
-                include_dirs: to_vec(map_get(term, "include_dirs")?)?
-                    .iter()
-                    .map(to_abs_path)
-                    .collect::<Result<_>>()?,
+                include_dirs: include_dirs.clone(),
                 macros: to_vec(map_get(term, "macros")?)?.to_owned(),
                 parse_transforms: to_vec(map_get(term, "parse_transforms")?)?.to_owned(),
                 app_type: is_dep,
-                include_path: vec![],
+                include_path: include_dirs,
                 abs_src_dirs,
             })
         }


### PR DESCRIPTION
This is a follow up of https://github.com/WhatsApp/eqwalizer/pull/49 to set both the `include_dirs` and `include_path` entries for apps that are created from `rebar3` build-info.

Explanation: https://github.com/WhatsApp/eqwalizer/pull/49#issuecomment-1847451510