### PR TITLE
CI: fix macOS x86_64 builds for eqWAlizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        platform-arch: [ubuntu-20.04-x64, ubuntu-20.04-arm, macos-latest-x64, macos-latest-arm]
+        platform-arch: [ubuntu-20.04-x64, ubuntu-20.04-arm, macos-13-x64, macos-latest-arm]
         otp-version: [25.3, 26.2]
         include:
           - otp-version: 25.3
@@ -30,8 +30,8 @@ jobs:
             os: linux
             target: aarch64-unknown-linux-gnu
             vscode-target: linux-arm64
-          - platform-arch: macos-latest-x64
-            platform: macos-latest
+          - platform-arch: macos-13-x64
+            platform: macos-13
             os: macos
             target: x86_64-apple-darwin
             vscode-target: darwin-x64
@@ -81,7 +81,9 @@ jobs:
         run: brew install erlang@${{ matrix.brew-otp-version }}
       - name: Add erl to path (MacOS Only)
         if: matrix.os == 'macos'
-        run: "echo '/opt/homebrew/opt/erlang@${{ matrix.brew-otp-version }}/bin' >> $GITHUB_PATH"
+        run: |
+          echo '/opt/homebrew/opt/erlang@${{ matrix.brew-otp-version }}/bin' >> $GITHUB_PATH
+          echo '/usr/local/opt/erlang@${{ matrix.brew-otp-version }}/bin' >> $GITHUB_PATH
       - name: Verify Erlang version
         run: erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell
       - name: Install rebar3


### PR DESCRIPTION
The CI was building eqWAlizer for arm64 even when targeting x86_64. This is due to the fact that the `macos-latest` runner is now always running on arm64 machines.

Fix by using `macos-13` runner.