### PR TITLE
Restore OTP 25 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,11 @@ jobs:
     strategy:
       matrix:
         platform-arch: [ubuntu-20.04-x64, ubuntu-20.04-arm, macos-13-x64, macos-latest-arm]
-        otp-version: [ 26.2]
+        otp-version: [25.3, 26.2]
         include:
+          - otp-version: 25.3
+            brew-otp-version: 25
+            vscode-publish: true
           - otp-version: 26.2
             brew-otp-version: 26
             vscode-publish: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             vscode-publish: true
           - otp-version: 26.2
             brew-otp-version: 26
-            vscode-publish: true
+            vscode-publish: false
           - platform-arch: ubuntu-20.04-x64
             platform: ubuntu-20.04
             os: linux

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,6 +2175,8 @@ dependencies = [
 [[package]]
 name = "tree-sitter-erlang"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192ccd449ddc472fbbf0ff4ed1ad8402410614674599acdcba456abb1178c68"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/erlang_service/src/elp_lint.erl
+++ b/erlang_service/src/elp_lint.erl
@@ -1419,7 +1419,7 @@ check_unused_records(Forms, St0) ->
                                          maps:remove(Used, Recs)
                                  end, St1#lint.records, UsedRecords),
             Unused = [{Name,Anno} ||
-                         Name := {Anno,_Fields} <- URecs,
+                         {Name, {Anno,_Fields}} <- maps:to_list(URecs),
                          element(1, loc(Anno, St1)) =:= FirstFile],
             foldl(fun ({N,Anno}, St) ->
                           add_warning(Anno, {unused_record, N}, St)
@@ -2217,8 +2217,8 @@ is_guard_test(Expression, Forms, IsOverridden) ->
     %% processing the forms until we'll know that the record
     %% definitions are truly needed.
     F = fun() ->
-                #{Name => {A,Fs} ||
-                    {attribute, A, record, {Name, Fs}} <- Forms}
+                Forms1 = [{Name, {A, Fs}} || {attribute, A, record, {Name, Fs}} <- Forms],
+                maps:from_list(Forms1)
         end,
 
     is_guard_test2(NoFileExpression, {F,IsOverridden}).
@@ -3394,7 +3394,7 @@ check_unused_types_1(Forms, #lint{types=Ts}=St) ->
 
 reached_types(#lint{usage = Usage}) ->
     Es = [{From, {type, To}} ||
-             To := UsedTs <- Usage#usage.used_types,
+             {To, UsedTs} <- maps:to_list(Usage#usage.used_types),
              #used_type{at = From} <- UsedTs],
     Initial = initially_reached_types(Es),
     G = sofs:family_to_digraph(sofs:rel2fam(sofs:relation(Es))),


### PR DESCRIPTION
I've read about the failure mentioned in #37. It's because the `erlang_service` uses the new map comprehension syntax introduced in OTP 26.

Only three places use the new syntax. Can we restore OTP 25 support by replacing the map comprehension with the legacy `maps:to_list`/`maps:from_list`?  I have built the `elp` based on `2024-07-16` and `2024-08-05`, seems to work fine.