### PR TITLE
Disable eqwalizer for OTP < 26

### DIFF
--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -12,6 +12,7 @@ use std::hash::Hash;
 use std::path::Path;
 use std::sync::Arc;
 
+use elp_project_model::otp::Otp;
 use elp_project_model::AppName;
 use elp_project_model::AppType;
 use elp_project_model::EqwalizerConfig;
@@ -194,6 +195,8 @@ impl AppStructure {
             db.set_project_data(project_id, Arc::new(project_data));
         }
         db.set_catch_all_source_root(self.catch_all_source_root);
+
+        db.set_otp_version(Otp::otp_version().ok());
     }
 }
 

--- a/crates/base_db/src/lib.rs
+++ b/crates/base_db/src/lib.rs
@@ -148,6 +148,9 @@ pub trait SourceDatabase: FileLoader + salsa::Database {
     #[salsa::input]
     fn project_data(&self, id: ProjectId) -> Arc<ProjectData>;
 
+    #[salsa::input]
+    fn otp_version(&self) -> Option<String>;
+
     /// A revision number that is bumped when the file state changes.
     /// Crucially, we update it in server mode when the unsaved file
     /// contents are changed in VFS, but also when we receive a

--- a/crates/ide_db/src/eqwalizer.rs
+++ b/crates/ide_db/src/eqwalizer.rs
@@ -154,6 +154,9 @@ fn is_eqwalizer_enabled(
     file_id: FileId,
     include_generated: bool,
 ) -> bool {
+    if !otp_supported_by_eqwalizer(db) {
+        return false;
+    }
     if !include_generated && db.is_generated(file_id) {
         return false;
     }
@@ -176,6 +179,12 @@ fn is_eqwalizer_enabled(
     let opt_in = (app_or_global_opt_in && is_src) || db.has_eqwalizer_module_marker(file_id);
     let ignored = db.has_eqwalizer_ignore_marker(file_id);
     opt_in && !ignored
+}
+
+fn otp_supported_by_eqwalizer(db: &dyn EqwalizerDatabase) -> bool {
+    db.otp_version()
+        .and_then(|v| Some(v.as_str() > "25"))
+        .unwrap_or(true)
 }
 
 fn has_eqwalizer_app_marker(db: &dyn EqwalizerDatabase, source_root_id: SourceRootId) -> bool {


### PR DESCRIPTION
Summary:
OSS users want to use ELP with OTP < 26.
But eqwalizer does not support this.
So disable eqwalizer diagnostics in this case.

Differential Revision: D61660600
