### PR TITLE
Avoid `fs::canonicalize` for project model paths

### DIFF
--- a/crates/elp/src/project_loader.rs
+++ b/crates/elp/src/project_loader.rs
@@ -30,7 +30,6 @@ impl ProjectLoader {
         let mut project_roots = FxHashMap::default();
         let otp_root = Otp::find_otp();
         if let Ok(otp_root) = otp_root {
-            let otp_root = AbsPathBuf::assert(otp_root);
             project_roots.insert(otp_root, None);
         }
         let start = SystemTime::now();

--- a/crates/project_model/src/buck.rs
+++ b/crates/project_model/src/buck.rs
@@ -160,7 +160,7 @@ impl BuckProject {
     pub fn load_from_config(
         buck_conf: &BuckConfig,
         query_config: &BuckQueryConfig,
-    ) -> Result<(BuckProject, Vec<ProjectAppData>, Utf8PathBuf), anyhow::Error> {
+    ) -> Result<(BuckProject, Vec<ProjectAppData>, AbsPathBuf), anyhow::Error> {
         let target_info = load_buck_targets(buck_conf, query_config)?;
         let otp_root = Otp::find_otp()?;
         let project_app_data = targets_to_project_data(&target_info.targets, &otp_root);
@@ -591,7 +591,7 @@ fn examine_path(path: &AbsPath, dir_based_on_buck_file: &AbsPath) -> Option<AbsP
 
 pub fn targets_to_project_data(
     targets: &FxHashMap<TargetFullName, Target>,
-    otp_root: &Utf8Path,
+    otp_root: &AbsPath,
 ) -> Vec<ProjectAppData> {
     let it = targets
         .values()
@@ -634,7 +634,7 @@ pub fn targets_to_project_data(
         .filter(|target| target.target_type != TargetType::ErlangTest)
         .filter_map(|target| target.dir.parent().map(|p| p.to_path_buf()))
         .collect();
-    global_inc.push(AbsPathBuf::assert(otp_root.to_path_buf()));
+    global_inc.push(otp_root.to_path_buf());
     for (_, mut acc) in accs {
         acc.add_global_includes(global_inc.clone());
         result.push(acc.into());

--- a/crates/project_model/src/lib.rs
+++ b/crates/project_model/src/lib.rs
@@ -947,25 +947,24 @@ impl Project {
             ProjectManifest::Json(config) => {
                 let otp_root = Otp::find_otp()?;
                 let config_path = config.config_path().to_path_buf();
-                let (mut apps, deps) = json::gen_app_data(config, AbsPath::assert(&otp_root));
+                let (mut apps, deps) = json::gen_app_data(config, &otp_root);
                 let project = StaticProject { config_path };
                 apps.extend(deps);
                 (ProjectBuildData::Static(project), apps, otp_root)
             }
             ProjectManifest::NoManifest(config) => {
                 let otp_root = Otp::find_otp()?;
-                let abs_otp_root = AbsPath::assert(&otp_root);
                 let config_path = config.config_path().to_path_buf();
-                let mut apps = config.to_project_app_data(abs_otp_root);
+                let mut apps = config.to_project_app_data(&otp_root);
                 let eqwalizer_support_app =
-                    eqwalizer_support::eqwalizer_suppport_data(abs_otp_root);
+                    eqwalizer_support::eqwalizer_suppport_data(&otp_root);
                 let project = StaticProject { config_path };
                 apps.push(eqwalizer_support_app);
                 (ProjectBuildData::Static(project), apps, otp_root)
             }
         };
 
-        let (otp, otp_project_apps) = Otp::discover(otp_root);
+        let (otp, otp_project_apps) = Otp::discover(&otp_root);
         project_apps.extend(otp_project_apps);
         Ok(Project {
             otp,

--- a/crates/project_model/src/rebar.rs
+++ b/crates/project_model/src/rebar.rs
@@ -142,14 +142,14 @@ impl RebarProject {
     pub fn from_rebar_build_info(
         path: impl AsRef<Path>,
         rebar_config: RebarConfig,
-    ) -> Result<(RebarProject, Utf8PathBuf, Vec<ProjectAppData>)> {
+    ) -> Result<(RebarProject, AbsPathBuf, Vec<ProjectAppData>)> {
         Self::_from_rebar_build_info(path.as_ref(), rebar_config)
     }
 
     fn _from_rebar_build_info(
         path: &Path,
         rebar_config: RebarConfig,
-    ) -> Result<(RebarProject, Utf8PathBuf, Vec<ProjectAppData>)> {
+    ) -> Result<(RebarProject, AbsPathBuf, Vec<ProjectAppData>)> {
         let data = fs::read(path)?;
         let mut build_info = eetf::Term::decode(&*data)?;
         let otp_root = into_abs_path(map_pop(&mut build_info, "otp_lib_dir")?)?;


### PR DESCRIPTION
I'm looking at using ELP on my system and am running into some issues with the way symlinks are handled.

For some background: I use [impermanence](https://github.com/nix-community/impermanence) so directories like `~/src` on my system are actually symlinks to `/nix/persist/home/michael/src`. It should be possible to reproduce everything I see with a simpler setup though, for example cloning a rebar3 project to `~/source/proj` on your machine, creating a symlink at `~/dest/proj` that points to it, and opening an editor in `~/dest/proj`. For a practical example, you might symlink a local dependency under `_checkouts` in a rebar project and go through the symlink to edit the dependency.

The problem is canonicalization: `fs::canonicalize`/`Path::canonicalize` resolve symlinks. Usually what you're actually looking for is normalization - resolving `.` and `..` and maybe stripping trailing `/`s - and making relative directories absolute to a given root. The VFS having canonicalized paths is a problem since the LSP client can send non-canonicalized paths which would appear to the VFS to be different files. You might think that canonicalizing incoming paths from the client is the solution here but it's a false trail: the effect would be that the response to `textDocument/definition` for example would include canonicalized paths and the client would consider them to be different buffers than the non-canonicalized paths in the request. Instead we should avoid canonicalization entirely.

So this PR removes canonicalization from the `project_model` crate and another instance of it in the `build-info` CLI.

This will also need a change in rebar3 to update how it retrieves the CWD. Like `std::env::current_dir`, `file:get_cwd()` uses getcwd(3) under the hood so `rebar_dir:get_cwd/0` will need an adaptation of the new `current_dir` function in the last commit. I have some changes locally that I will send and link here. (Edit: https://github.com/erlang/rebar3/pull/2925)