### PR TITLE
Prevent completion within comments

### DIFF
--- a/crates/ide_completion/src/ctx.rs
+++ b/crates/ide_completion/src/ctx.rs
@@ -21,6 +21,7 @@ use elp_syntax::TextSize;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CtxKind {
+    Comment,
     Expr,
     Type,
     Export,
@@ -32,7 +33,9 @@ pub enum CtxKind {
 
 impl CtxKind {
     pub fn new(node: &SyntaxNode, offset: TextSize) -> Self {
-        if Self::is_atom_colon(node, offset) && Self::is_expr(node, offset) {
+        if Self::is_comment(node, offset) {
+            Self::Comment
+        } else if Self::is_atom_colon(node, offset) && Self::is_expr(node, offset) {
             Self::Expr
         } else if Self::is_export(node, offset) {
             Self::Export
@@ -55,6 +58,12 @@ impl CtxKind {
         } else {
             Self::Other
         }
+    }
+    fn is_comment(node: &SyntaxNode, offset: TextSize) -> bool {
+        algo::ancestors_at_offset(node, offset)
+            .into_iter()
+            .flatten()
+            .any(|ancestor| ancestor.kind() == SyntaxKind::COMMENT)
     }
     fn is_atom_colon(node: &SyntaxNode, offset: TextSize) -> bool {
         if let Some(parent) = algo::ancestors_at_offset(node, offset).and_then(|mut ns| ns.next()) {

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -132,6 +132,7 @@ pub fn completions(
     };
 
     match ctx_kind {
+        CtxKind::Comment => (),
         CtxKind::Expr => {
             let _ = macros::add_completions(&mut acc, ctx)
                 || records::add_completions(&mut acc, ctx)

--- a/crates/ide_completion/src/tests.rs
+++ b/crates/ide_completion/src/tests.rs
@@ -24,3 +24,33 @@ pub(crate) fn get_completions(code: &str, trigger_character: Option<char>) -> Ve
     let (db, position, _) = RootDatabase::with_position(code);
     crate::completions(&db, position, trigger_character)
 }
+
+#[test]
+fn no_completions_in_comments() {
+    assert_eq!(
+        render_completions(get_completions(
+            r#"
+-module(hello).
+-export([hello/0]).
+%% Hello, world! ~
+hello() ->
+    world.
+"#,
+            None
+        )),
+        ""
+    );
+
+    assert_eq!(
+        render_completions(get_completions(
+            r#"
+-module(hello).
+-export([hello/0]).
+hello() ->
+    world. %% Hello, world! ~
+"#,
+            None
+        )),
+        ""
+    );
+}


### PR DESCRIPTION
This matches [rust-analyzer's behavior](https://github.com/rust-lang/rust-analyzer/blob/c0bbbb3e5d7d1d1d60308c8270bfd5b250032bb4/crates/ide-completion/src/tests.rs#L299-L330) in comments: completions are avoided completely. Ocassionally the completions can be useful (for example completing a parameter while writing docs for a function) but on balance I think the completions are noisier than they are helpful. Maybe there's room in the long run to be smarter about completions in comments (similar to [rust-analyzer#4170](https://redirect.github.com/rust-lang/rust-analyzer/issues/4170)) but without that I think it's better to avoid completions in comments entirely.