### PR TITLE
Move salsa cancellation into `Drop for Server`

### DIFF
--- a/crates/elp/src/server.rs
+++ b/crates/elp/src/server.rs
@@ -256,6 +256,12 @@ pub struct Server {
     vfs_config_version: u32,
 }
 
+impl Drop for Server {
+    fn drop(&mut self) {
+        self.analysis_host.request_cancellation();
+    }
+}
+
 impl Server {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -603,7 +609,6 @@ impl Server {
         RequestDispatcher::new(self, req)
             .on_sync::<request::Shutdown>(|this, ()| {
                 this.transition(Status::ShuttingDown);
-                this.analysis_host.request_cancellation();
                 Ok(())
             })?
             .on::<request::CodeActionRequest>(handlers::handle_code_action)


### PR DESCRIPTION
I'm not super familiar with the salsa internals but it seems as though if the database is modified between the receipt of `request::Shutdown` and `notification::Exit` then the `Drop` for `Server` deadlocks. This is fairly easy to trigger especially on a debug build by quitting an editor like neovim soon after starting the language server. Moving the cancellation request into `Drop` matches rust-analyzer and seems to avoid the deadlock - I believe because it closes the window where the database could be edited between cancel and drop.

Fixes https://github.com/WhatsApp/erlang-language-platform/issues/36