### PR TITLE
Fix `Drop for Server` deadlock behavior

### DIFF
--- a/crates/elp_log/src/lib.rs
+++ b/crates/elp_log/src/lib.rs
@@ -72,6 +72,13 @@ impl Logger {
         log::set_max_level(shared.max_level());
     }
 
+    pub fn remove_logger(&self, name: &str) {
+        let mut shared = self.shared.write();
+        shared.writers.remove(name.into());
+
+        log::set_max_level(shared.max_level());
+    }
+
     pub fn reconfigure(&self, name: &str, filter: Builder) {
         let mut shared = self.shared.write();
 


### PR DESCRIPTION
This fixes two possible deadlocks that cause `elp server` to hang during exit. I was on the right track in #74 but there are actually two deadlocks:

* The first happens because the logger backend has a clone of the `Sender` of the `Connection` (because the `LspLogger` clones it one). This can cause a deadlock when a message is _not_ logged following the drop of `Server` on `io_threads.join()` because the `Connection`'s thread for receiving messages from the `Connection`'s `Receiver` awaits messages indefinitely. The solution for this deadlock is to remove the `LspLogger` from the backend on `Drop` of the server (or any time earlier). That decrements the reference count on the `Sender` and causes the `Receiver`'s iterator to return `None` resulting in the termination of its thread.
* The second I don't really understand fully. The `Drop for Server` hangs because the cache task pool's drop joins its threads (by design) and there is an outstanding task that seems to be frozen, I think related to Salsa's cancellation mechanism. Explicitly requesting cancellation during drop eliminates this problem. Plus it matches what rust-analyzer does.

Fixes #36