### PR TITLE
Fix command line option parsing

### DIFF
--- a/crates/elp/src/bin/args.rs
+++ b/crates/elp/src/bin/args.rs
@@ -151,13 +151,13 @@ pub struct EqwalizeTarget {
     pub project: PathBuf,
     /// Also eqwalize opted-in generated modules from application
     pub include_generated: bool,
-    /// target, like //erl/chatd/...
-    #[bpaf(positional::< String > ("TARGET"))]
-    pub target: String,
     /// Use experimental clause coverage checker
     pub clause_coverage: bool,
     /// Exit with a non-zero status code if any errors are found
     pub bail_on_error: bool,
+    /// target, like //erl/chatd/...
+    #[bpaf(positional("TARGET"))]
+    pub target: String,
 }
 
 #[derive(Clone, Debug, Bpaf)]


### PR DESCRIPTION
Positional arguments in 0.9 version of bpaf must go to the right most position.

Fixes https://github.com/WhatsApp/erlang-language-platform/issues/85