### PR TITLE
Update debug code-lenses so they work with rebar3 and latest edb version

### DIFF
--- a/editors/code/client/src/commands.ts
+++ b/editors/code/client/src/commands.ts
@@ -109,17 +109,20 @@ export async function debugSingle(runnable: Runnable): Promise<void> {
         type: edbDebugger.DEBUG_TYPE,
         name: 'Erlang EDB',
         request: 'launch',
-        launchCommand: {
+        runInTerminal: {
+            kind: "integrated",
             cwd: "${workspaceFolder}",
-            command: "rebar3",
-            arguments: [
-                "ct",
-                "--sname",
-                "debuggee",
-                runnable.args.args
-            ]
+            args: ["bash", "-c", "rebar3 as test shell --eval \"$EDB_DAP_NODE_INIT, $REBAR3_SHELL_CT_RUN_CMD\""],
+            env: {
+                REBAR3_SHELL_CT_RUN_CMD: `gen_server:cast(self(), {cmd, default, ct, \"${runnable.args.args.join(" ")}\"})`
+            },
+            argsCanBeInterpretedByShell: false,
         },
-        targetNode: 'debuggee'
+        config: {
+            nameDomain: "shortnames",
+            nodeInitCodeInEnvVar: "EDB_DAP_NODE_INIT",
+            timeout: 60,
+        },
     };
     await vscode.debug.startDebugging(undefined, debugConfiguration);
 }

--- a/editors/code/client/src/commands.ts
+++ b/editors/code/client/src/commands.ts
@@ -114,7 +114,8 @@ export async function debugSingle(runnable: Runnable): Promise<void> {
             cwd: "${workspaceFolder}",
             args: ["bash", "-c", "rebar3 as test shell --eval \"$EDB_DAP_NODE_INIT, $REBAR3_SHELL_CT_RUN_CMD\""],
             env: {
-                REBAR3_SHELL_CT_RUN_CMD: `gen_server:cast(self(), {cmd, default, ct, \"${runnable.args.args.join(" ")}\"})`
+                REBAR3_SHELL_CT_RUN_CMD: `gen_server:cast(self(), {cmd, default, ct, \"${runnable.args.args.join(" ")}\"})`,
+                "PATH": dapConfig.withErlangInstallationPath(),
             },
             argsCanBeInterpretedByShell: false,
         },

--- a/editors/code/client/src/debugger.ts
+++ b/editors/code/client/src/debugger.ts
@@ -86,7 +86,11 @@ class EDBConfigurationProvider implements vscode.DebugConfigurationProvider {
             }
         }
 
-        config.launchCommand.env = { "PATH": dapConfig.withErlangInstallationPath() };
+        config.runInTerminal.env = {
+            ...config.runInTerminal.env,
+             "PATH": dapConfig.withErlangInstallationPath() 
+        };
+
         return config;
     }
 }

--- a/editors/code/client/src/debugger.ts
+++ b/editors/code/client/src/debugger.ts
@@ -26,9 +26,6 @@ export interface EdbDebugConfiguration extends vscode.DebugConfiguration {
 }
 
 export function activateDebugger(context: vscode.ExtensionContext) {
-    const provider = new EDBConfigurationProvider();
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(DEBUG_TYPE, provider));
-
     const factory = new DebugAdapterExecutableFactory(context.extensionUri);
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory(DEBUG_TYPE, factory));
 }
@@ -55,42 +52,5 @@ class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescriptorFact
         const options = { env: { "PATH": dapConfig.withErlangInstallationPath() } };
         executable = new vscode.DebugAdapterExecutable(command, args, options);
         return executable;
-    }
-}
-
-class EDBConfigurationProvider implements vscode.DebugConfigurationProvider {
-
-    resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
-
-        // if launch.json is missing or empty
-        if (!config.type && !config.request && !config.name) {
-            const editor = vscode.window.activeTextEditor;
-            if (editor && editor.document.languageId === 'erlang') {
-                config.type = DEBUG_TYPE;
-                config.name = 'Erlang EDB';
-                config.request = 'launch';
-                config.launchCommand = {
-                    cwd: "${workspaceFolder}",
-                    command: "rebar3",
-                    arguments: [
-                        "as",
-                        "test",
-                        "shell",
-                        "--sname",
-                        "debuggee"
-                    ]
-                };
-                config.targetNode = {
-                    name: "debuggee"
-                };
-            }
-        }
-
-        config.runInTerminal.env = {
-            ...config.runInTerminal.env,
-             "PATH": dapConfig.withErlangInstallationPath() 
-        };
-
-        return config;
     }
 }

--- a/editors/code/client/src/extension.ts
+++ b/editors/code/client/src/extension.ts
@@ -11,6 +11,7 @@
 import * as vscode from 'vscode';
 import { activateDebugger } from './debugger';
 import { registerCommands } from './commands';
+import { outputChannel } from './logging';
 import * as path from 'path';
 
 import {
@@ -22,13 +23,11 @@ import {
 import { CodeAction317, resolveCodeActionData } from './lspExtensions';
 
 let client: LanguageClient;
-let log: vscode.OutputChannel;
 
 export const ELP = 'elpClient';
 
 export function activate(context: vscode.ExtensionContext) {
-
-	log = vscode.window.createOutputChannel('Erlang ELP');
+	const log = outputChannel();
 
 	// Options to control the language server
 	const config = vscode.workspace.getConfiguration(ELP);
@@ -74,10 +73,11 @@ export function activate(context: vscode.ExtensionContext) {
 		clientOptions
 	);
 
+	log.appendLine('Registering commands');
 	registerCommands(context, client);
 
-	log.append('Activating debugger');
 	// Activate the DAP Debugger
+	log.appendLine('Activating debugger');
 	activateDebugger(context);
 
 	// Start the client. This will also launch the server

--- a/editors/code/client/src/logging.ts
+++ b/editors/code/client/src/logging.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+import * as vscode from 'vscode';
+
+let log: vscode.OutputChannel;
+
+export function outputChannel() {
+    if (log == undefined) {
+        log = vscode.window.createOutputChannel('Erlang ELP');
+    }
+
+    return log;
+}

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -73,27 +73,6 @@
         "type": "erlang-edb",
         "label": "Erlang EDB",
         "languages": ["erlang"],
-        "initialConfigurations": [
-          {
-            "name": "Erlang EDB",
-            "type": "erlang-edb",
-            "request": "launch",
-            "launchCommand": {
-              "cwd": "${workspaceFolder}",
-              "command": "rebar3",
-              "arguments": [
-                "as",
-                "test",
-                "shell",
-                "--sname",
-                "debuggee"
-              ]
-            },
-            "targetNode": {
-              "name": "debuggee@localhost"
-            }
-          }
-        ],
         "configurationSnippets": [
           {
             "label": "Erlang EDB: Launch Configuration (rebar3)",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -74,89 +74,122 @@
         "label": "Erlang EDB",
         "languages": ["erlang"],
         "configurationSnippets": [
-          {
-            "label": "Erlang EDB: Launch Configuration (rebar3)",
-            "description": "A new configuration for launching a rebar3 shell for the debuggee.",
+                    {
+            "label": "Launch rebar3 shell",
+            "description": "Launches rebar3 shell and connects it to the debugger",
             "body": {
-              "name": "Erlang EDB",
+              "name": "Launch rebar3 shell",
               "type": "erlang-edb",
               "request": "launch",
-              "launchCommand": {
+              "runInTerminal": {
+                "kind": "integrated",
                 "cwd": "${workspaceFolder}",
-                "command": "rebar3",
-                "arguments": [
-                  "as",
-                  "test",
-                  "shell",
-                  "--sname",
-                  "debuggee"
-                ]
+                "args": ["rebar3", "as", "test", "shell"]
               },
-              "targetNode": {
-                "name": "debuggee@localhost"
+              "config": {
+                "nameDomain": "shortnames"
+              }
+            }
+          },
+          {
+            "label": "Attach to Erlang node",
+            "description": "Attach to a node that must have been started with +D",
+            "body": {
+              "name": "Attach to node",
+              "type": "erlang-edb",
+              "request": "attach",
+              "config": {
+                "cwd": "${workspaceFolder}",
+                "node": "mynode@localhost"
               }
             }
           }
         ],
         "configurationAttributes": {
-          "launch": {
+          "attach": {
             "required": [
-              "launchCommand",
-              "targetNode"
+              "node",
+              "cwd"
             ],
             "properties": {
-              "launchCommand": {
+              "node": {
+                "type": "string",
+                "description": "The node to attach to."
+              },
+              "cookie": {
+                "type": "string",
+                "description": "Connection cookie."
+              },
+              "cwd": {
+                "type": "string",
+                "description": "Path to prepend to any relative source file found in beam files. Typically the workspace folder."
+              },
+              "stripSourcePrefix": {
+                "type": "string",
+                "description": "When source paths in beam files are relative, this can be used to strip a prefix so that they match the filename in the current workspace."
+              }
+            }
+          },
+          "launch": {
+            "required": [
+              "runInTerminal",
+              "config"
+            ],
+            "properties": {
+              "runInTerminal": {
                 "type": "object",
-                "description": "The command used to launch the debuggee (Erlang node under test).",
+                "description": "The RunInTerminal DAP command to use",
                 "required": [
-                  "command"
+                  "args",
+                  "cwd"
                 ],
                 "properties": {
-                  "command": {
-                    "type": "string",
-                    "description": "The command to launch an Erlang node via an external terminal"
-                  },
-                  "arguments": {
+                  "args": {
                     "type": "array",
-                    "description": "Arguments for the command.",
-                    "default": []
+                    "description": "The command to launch and all its arguments"
                   },
                   "cwd": {
                     "type": "string",
-                    "description": "Working directory for the program to start. Defaults to the Workspace Root.",
-                    "default": "${workspaceRoot}"
+                    "description": "Working directory for the node to launch"
                   },
                   "env": {
                     "type": "object",
                     "description": "Environment key-value pairs that are added to or removed from the default environment."
+                  },
+                  "kind": {
+                    "type": "string",
+                    "description": "Use an integrated or external terminal. Possible values: `integrated` (default) or `external`."
+                  },
+                  "argsCanBeInterpretedByShell": {
+                    "type": "boolean",
+                    "description": "Set to true if the args need to have environment variables expanded, etc. Default: false."
                   }
                 }
               },
-              "targetNode": {
+              "config": {
                 "type": "object",
-                "description": "Information about the debuggee (Erlang node under test), used by the debugger to connect via Erlang RPC.",
+                "description": "Debugger configuration",
                 "required": [
-                  "name"
+                  "nameDomain"
                 ],
                 "properties": {
-                  "name": {
+                  "nameDomain": {
                     "type": "string",
-                    "description": "The name of the Erlang node (e.g. my_node@my_host)."
+                    "description": "Should the debugger use shortnames or longnames."
                   },
-                  "cookie": {
+                  "nodeInitCodeInEnvVar": {
                     "type": "string",
-                    "description": "The cookie used to connect to the debuggee. If omitted, the default system cookie is used."
+                    "description": "If given, the initialization code for the node will be put in the given environment variable, which should then be mentioned in the `args`."
+                  },
+                  "stripSourcePrefix": {
+                    "type": "string",
+                    "description": "When source paths in beam files are relative, this can be used to strip a prefix so that they match the filename in the current workspace."
+                  },
+                  "timeout": {
+                    "type": "number",
+                    "description": "How long, in seconds, the debugger will wait for the new node to connect to it. Defaults to 60."
                   }
                 }
-              },
-              "timeout": {
-                "type": "integer",
-                "description": "Timeout for connecting to the project node after starting debugging.",
-                "default": 60
-              },
-              "stripSourcePrefix": {
-                "type": "string",
-                "description": "When specified, the string is stripped from the suffix of the `cwd`. Useful to guarantee that source paths are relative to the repo root, when this does not coincide with the current `cwd`."
               }
             }
           }


### PR DESCRIPTION
* Launch configurations were no longer valid
* Fixed the code to launch rebar3, so that it injects the necessary code to register with the debugger
* Updated documentation
* In the process, made it easier to log from the extension