### PR TITLE
[vscode extension] Fix the `configurationAttributes` of edb `Attach to Erlang Node` option

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -108,25 +108,34 @@
         "configurationAttributes": {
           "attach": {
             "required": [
-              "node",
-              "cwd"
+              "config"
             ],
             "properties": {
-              "node": {
-                "type": "string",
-                "description": "The node to attach to."
-              },
-              "cookie": {
-                "type": "string",
-                "description": "Connection cookie."
-              },
-              "cwd": {
-                "type": "string",
-                "description": "Path to prepend to any relative source file found in beam files. Typically the workspace folder."
-              },
-              "stripSourcePrefix": {
-                "type": "string",
-                "description": "When source paths in beam files are relative, this can be used to strip a prefix so that they match the filename in the current workspace."
+              "config": {
+                "type": "object",
+                "description": "Debugger configuration",
+                "required": [
+                  "node",
+                  "cwd"
+                ],
+                "properties": {
+                  "node": {
+                    "type": "string",
+                    "description": "The node to attach to."
+                  },
+                  "cookie": {
+                    "type": "string",
+                    "description": "Connection cookie."
+                  },
+                  "cwd": {
+                    "type": "string",
+                    "description": "Path to prepend to any relative source file found in beam files. Typically the workspace folder."
+                  },
+                  "stripSourcePrefix": {
+                    "type": "string",
+                    "description": "When source paths in beam files are relative, this can be used to strip a prefix so that they match the filename in the current workspace."
+                  }
+                }
               }
             }
           },


### PR DESCRIPTION
The configuration attributes were misconfigured. When using `Attach to Erlang Node` launch.json 
complains about missing properties of "node", "cwd", and property  "config" is not allowed.
    
So, update these attributes in package.json to fix the issues.

before:
<img width="375" alt="Screenshot 2568-05-30 at 00 37 11" src="https://github.com/user-attachments/assets/e1c794f8-3704-4c6c-b4c8-85888a8d1678" />

<img width="310" alt="Screenshot 2568-05-30 at 00 37 01" src="https://github.com/user-attachments/assets/40ec2068-5b7e-4200-8181-aed9ff63011b" />

after:
<img width="333" alt="Screenshot 2568-05-30 at 01 05 09" src="https://github.com/user-attachments/assets/46ee20a4-cd06-4e99-9985-c3e802741864" />
