### PR TITLE
BinaryStringToSigil: Ignore multi-line binary strings

### DIFF
--- a/crates/ide/src/diagnostics/binary_string_to_sigil.rs
+++ b/crates/ide/src/diagnostics/binary_string_to_sigil.rs
@@ -71,6 +71,11 @@ fn make_diagnostic(sema: &Semantic, matched: &Match) -> Option<Diagnostic> {
         return None;
     }
 
+    // Ignore multi-line binary strings
+    if string_content_match_src.contains('\n') {
+        return None;
+    }
+
     let mut builder = SourceChangeBuilder::new(file_id);
     let sigil_string = format!("~{string_content_match_src}");
     builder.replace(binary_string_range, sigil_string);
@@ -171,6 +176,19 @@ mod tests {
          fn() ->
              ~"monkey ~2..0b\n",
              ~b"monkey ~2..0b\n".
+            "#,
+        )
+    }
+
+    #[test]
+    fn ignores_multi_line_binary_string() {
+        check_diagnostics(
+            r#"
+         //- /src/binary_string_to_sigil.erl
+         -module(binary_string_to_sigil).
+
+         fn() -> <<"Hello everyone! "
+                   "Nice to meet you?">>.
             "#,
         )
     }


### PR DESCRIPTION
In the current implementation, the "binary string to sigil" fix will create syntactically invalid code when applied to multi-line binary strings. This PR makes it so that multi-line binary strings are ignored for this diagnostic.

Currently, the LSP will suggest replacing this:

```erl
<<"Hello everyone! "
  "Goodbye!">>
```

With this:

```erl
~"Hello everyone! "
 "Goodbye!"
```

This is not valid Erlang syntax as far as I've been able to tell, and I don't think there is any good equivalent "sigil syntax" variant for multi-line strings.

Let me know what you think! Thanks