### PR TITLE
json-config: also put deps include_dirs into include_path

### DIFF
--- a/crates/project_model/src/json.rs
+++ b/crates/project_model/src/json.rs
@@ -220,6 +220,9 @@ pub(crate) fn gen_app_data(
         include_path.extend(app.include_dirs());
         app.include_path = include_path.into_iter().collect();
     }
+    for app in &mut deps {
+        app.include_path = app.include_dirs();
+    }
     let eqwalizer_support_app = eqwalizer_support::eqwalizer_suppport_data(otp_root);
     deps.push(eqwalizer_support_app);
 


### PR DESCRIPTION
Currently elp does not find included files from a dependency's own (and properly configured) include_dirs, since they are not added to include_path.

As far as I can tell it is not always a viable workaround to put those deps into apps.
When a dep contains a parse_transform that is needed by erlang_service_lint.erl, it must be classified as a dep for its ebins to be available to erlang_service.