### PR TITLE
.elp.toml: add eqwalizer option ignore modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,9 +2538,10 @@ dependencies = [
 [[package]]
 name = "tree-sitter-erlang"
 version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93be1a3081a815ff6840d6b6741fc920817eb8843c3b97a026ef47a89f108cad"
 dependencies = [
  "cc",
- "tree-sitter",
  "tree-sitter-language",
 ]
 

--- a/crates/elp/src/bin/main.rs
+++ b/crates/elp/src/bin/main.rs
@@ -1946,6 +1946,36 @@ mod tests {
         }
     }
 
+    #[test]
+    fn eqwalize_specific_module_overrides_ignore_modules() {
+        if otp_supported_by_eqwalizer() {
+            simple_snapshot_expect_error(
+                args_vec!["eqwalize", "--bail-on-error", "app_b"],
+                "eqwalizer_ignore_modules",
+                expect_file!(
+                    "../resources/test/eqwalizer_ignore_modules/eqwalize_bail_on_error_failure.pretty"
+                ),
+                true,
+                None,
+            );
+        }
+    }
+
+    #[test]
+    fn eqwalize_all_ignore_modules_success() {
+        if otp_supported_by_eqwalizer() {
+            simple_snapshot(
+                args_vec!["eqwalize-all", "--bail-on-error"],
+                "eqwalizer_ignore_modules",
+                expect_file!(
+                    "../resources/test/eqwalizer_ignore_modules/eqwalize_all_bail_on_error_success.pretty"
+                ),
+                true,
+                None,
+            );
+        }
+    }
+
     // -----------------------------------------------------------------
 
     #[test]

--- a/crates/elp/src/resources/test/eqwalizer_ignore_modules/eqwalize_all_bail_on_error_success.pretty
+++ b/crates/elp/src/resources/test/eqwalizer_ignore_modules/eqwalize_all_bail_on_error_success.pretty
@@ -1,0 +1,1 @@
+NO ERRORS

--- a/crates/elp/src/resources/test/eqwalizer_ignore_modules/eqwalize_bail_on_error_failure.pretty
+++ b/crates/elp/src/resources/test/eqwalizer_ignore_modules/eqwalize_bail_on_error_failure.pretty
@@ -1,0 +1,9 @@
+error: incompatible_types (See https://fb.me/eqwalizer_errors#incompatible_types)
+  ┌─ apps/app_b/src/app_b.erl:5:15
+  │
+5 │ test_fun() -> type_error.
+  │               ^^^^^^^^^^ 'type_error'.
+Expression has type:   'type_error'
+Context expected type: 'ok'
+
+1 ERROR

--- a/crates/ide_db/src/eqwalizer.rs
+++ b/crates/ide_db/src/eqwalizer.rs
@@ -185,7 +185,10 @@ fn is_eqwalizer_enabled(db: &dyn EqwalizerDatabase, file_id: FileId, include_tes
     let global_opt_in = eqwalizer_config.enable_all;
     let opt_in =
         (global_opt_in && (is_src || is_test_opted_in)) || db.has_eqwalizer_module_marker(file_id);
-    let ignored = db.has_eqwalizer_ignore_marker(file_id);
+    let ignored_in_config = if let Some(module_name) = module_index.module_for_file(file_id) {
+        eqwalizer_config.ignore_modules.iter().any(|m| m == module_name.as_str())
+    } else { false };
+    let ignored = ignored_in_config || db.has_eqwalizer_ignore_marker(file_id);
     opt_in && !ignored
 }
 

--- a/crates/ide_db/src/eqwalizer.rs
+++ b/crates/ide_db/src/eqwalizer.rs
@@ -186,8 +186,13 @@ fn is_eqwalizer_enabled(db: &dyn EqwalizerDatabase, file_id: FileId, include_tes
     let opt_in =
         (global_opt_in && (is_src || is_test_opted_in)) || db.has_eqwalizer_module_marker(file_id);
     let ignored_in_config = if let Some(module_name) = module_index.module_for_file(file_id) {
-        eqwalizer_config.ignore_modules.iter().any(|m| m == module_name.as_str())
-    } else { false };
+        eqwalizer_config
+            .ignore_modules
+            .iter()
+            .any(|m| m == module_name.as_str())
+    } else {
+        false
+    };
     let ignored = ignored_in_config || db.has_eqwalizer_ignore_marker(file_id);
     opt_in && !ignored
 }

--- a/crates/ide_db/src/eqwalizer.rs
+++ b/crates/ide_db/src/eqwalizer.rs
@@ -187,9 +187,11 @@ fn is_eqwalizer_enabled(db: &dyn EqwalizerDatabase, file_id: FileId, include_tes
         (global_opt_in && (is_src || is_test_opted_in)) || db.has_eqwalizer_module_marker(file_id);
     let ignored_in_config = if let Some(module_name) = module_index.module_for_file(file_id) {
         eqwalizer_config
-            .ignore_modules
+            .ignore_modules_compiled_patterns
             .iter()
-            .any(|m| m == module_name.as_str())
+            .any(|pattern| {
+                pattern.matches(module_name.as_str())
+            })
     } else {
         false
     };

--- a/crates/project_model/src/lib.rs
+++ b/crates/project_model/src/lib.rs
@@ -35,6 +35,7 @@ use elp_log::timeit;
 use fxhash::FxHashMap;
 use fxhash::FxHashSet;
 use glob::glob;
+use glob::Pattern;
 use itertools::Either;
 use itertools::Itertools;
 use json::JsonProjectAppData;
@@ -404,6 +405,9 @@ pub struct EqwalizerConfig {
     pub max_tasks: usize,
     #[serde(default = "eqwalizer_ignore_modules_default")]
     pub ignore_modules: Vec<String>,
+    #[serde(skip_deserializing)]
+    #[serde(skip_serializing)]
+    pub ignore_modules_compiled_patterns: Vec<Pattern>,
 }
 
 fn eqwalizer_enable_all_default() -> bool {
@@ -424,7 +428,15 @@ impl Default for EqwalizerConfig {
             enable_all: eqwalizer_enable_all_default(),
             max_tasks: eqwalizer_max_tasks_default(),
             ignore_modules: eqwalizer_ignore_modules_default(),
+            ignore_modules_compiled_patterns: vec![],
         }
+    }
+}
+
+impl EqwalizerConfig {
+    pub fn compile_patterns(&mut self) {
+        self.ignore_modules_compiled_patterns = self.ignore_modules.iter()
+            .map(|s| Pattern::new(s).unwrap()).collect();
     }
 }
 
@@ -514,6 +526,7 @@ impl ElpConfig {
             Ok(mut config) => {
                 BuckConfig::make_config(&path, &mut config)?;
                 config.config_path = Some(path);
+                config.eqwalizer.compile_patterns();
 
                 Ok(config)
             }
@@ -1783,6 +1796,7 @@ mod tests {
                 enable_all: true,
                 max_tasks: 34,
                 ignore_modules: vec!["some_module".to_string()],
+                ignore_modules_compiled_patterns: vec![Pattern::new("some_module").unwrap()],
             },
             rebar: ElpRebarConfig {
                 profile: "my_profile".to_string(),

--- a/crates/project_model/src/lib.rs
+++ b/crates/project_model/src/lib.rs
@@ -402,6 +402,8 @@ pub struct EqwalizerConfig {
     pub enable_all: bool,
     #[serde(default = "eqwalizer_max_tasks_default")]
     pub max_tasks: usize,
+    #[serde(default = "eqwalizer_ignore_modules_default")]
+    pub ignore_modules: Vec<String>,
 }
 
 fn eqwalizer_enable_all_default() -> bool {
@@ -412,11 +414,16 @@ fn eqwalizer_max_tasks_default() -> usize {
     4
 }
 
+fn eqwalizer_ignore_modules_default() -> Vec<String> {
+    vec![]
+}
+
 impl Default for EqwalizerConfig {
     fn default() -> Self {
         Self {
             enable_all: eqwalizer_enable_all_default(),
             max_tasks: eqwalizer_max_tasks_default(),
+            ignore_modules: eqwalizer_ignore_modules_default(),
         }
     }
 }
@@ -1775,6 +1782,7 @@ mod tests {
             eqwalizer: EqwalizerConfig {
                 enable_all: true,
                 max_tasks: 34,
+                ignore_modules: vec!["some_module".to_string()],
             },
             rebar: ElpRebarConfig {
                 profile: "my_profile".to_string(),
@@ -1797,6 +1805,7 @@ mod tests {
             [eqwalizer]
             enable_all = true
             max_tasks = 34
+            ignore_modules = ["some_module"]
 
             [rebar]
             profile = "my_profile"

--- a/test_projects/eqwalizer_ignore_modules/.elp.toml
+++ b/test_projects/eqwalizer_ignore_modules/.elp.toml
@@ -1,0 +1,6 @@
+[build_info]
+apps = "apps/*"
+deps = "deps/*"
+
+[eqwalizer]
+ignore_modules = ["*_a", "app_b"]

--- a/test_projects/eqwalizer_ignore_modules/apps/app_a/include/app_a.hrl
+++ b/test_projects/eqwalizer_ignore_modules/apps/app_a/include/app_a.hrl
@@ -1,0 +1,1 @@
+-compile(debug_info).

--- a/test_projects/eqwalizer_ignore_modules/apps/app_a/src/another_module_a.erl
+++ b/test_projects/eqwalizer_ignore_modules/apps/app_a/src/another_module_a.erl
@@ -1,0 +1,4 @@
+-module(another_module_a).
+
+-spec test_fun() -> ok.
+test_fun() -> type_error.

--- a/test_projects/eqwalizer_ignore_modules/apps/app_a/src/app_a.erl
+++ b/test_projects/eqwalizer_ignore_modules/apps/app_a/src/app_a.erl
@@ -1,0 +1,4 @@
+-module(app_a).
+
+-spec test_fun() -> ok.
+test_fun() -> type_error.

--- a/test_projects/eqwalizer_ignore_modules/apps/app_b/src/app_b.erl
+++ b/test_projects/eqwalizer_ignore_modules/apps/app_b/src/app_b.erl
@@ -1,0 +1,5 @@
+-module(app_b).
+-include_lib("app_a/include/app_a.hrl").
+
+-spec test_fun() -> ok.
+test_fun() -> type_error.

--- a/website/docs/get-started/configure-project/elp-toml.md
+++ b/website/docs/get-started/configure-project/elp-toml.md
@@ -25,6 +25,7 @@ file = "my_hand_crafted_build_info.json"
 [eqwalizer]
 enable_all = true
 max_tasks = 32
+ingnore_modules = ["very_big_generated_module"]
 
 [buck]
 enabled = false
@@ -87,8 +88,7 @@ type checker. The integration can be configured via this section.
 
 :::info
 
-By default eqWAlizer is enabled on all non-test modules. It is also disabled for
-modules containing the `@generated` keyword within their first 2000 characters.
+By default eqWAlizer is enabled on all non-test modules, including generated modules.
 This can be overriden per module via the following attributes:
 
 - `-eqwalizer(ignore).` Opt-out module unconditionally
@@ -96,10 +96,11 @@ This can be overriden per module via the following attributes:
 
 :::
 
-| Key         | Type    | Description                                                                                                                                          |
-| ----------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| enabled_all | Boolean | Disable eqwalizer for all modules by default, but still honours the module-specific overrides listed above                                           |
-| max_tasks   | Integer | Max number of parallel eqWAlizer tasks, defaults to 4 (eqWAlizer instances are memory intensive). This only applies to using eqWAlizer from the CLI. |
+| Key            | Type           | Description                                                                                                                                          |
+| -------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| enabled_all    | Boolean        | Enable eqwalizer for all modules by default, but still honours the module-specific overrides listed above and the ignore_modules list.               |
+| max_tasks      | Integer        | Max number of parallel eqWAlizer tasks, defaults to 4 (eqWAlizer instances are memory intensive). This only applies to using eqWAlizer from the CLI. |
+| ignore_modules | List of String | Disable eqwalizer for individual modules from the config.                                                                                            |
 
 ### \[buck\] {#buck}
 

--- a/website/docs/get-started/configure-project/elp-toml.md
+++ b/website/docs/get-started/configure-project/elp-toml.md
@@ -25,7 +25,7 @@ file = "my_hand_crafted_build_info.json"
 [eqwalizer]
 enable_all = true
 max_tasks = 32
-ingnore_modules = ["very_big_generated_module"]
+ignore_modules = ["very_big_generated_module"]
 
 [buck]
 enabled = false


### PR DESCRIPTION
As the title says and as proposed in #67, this adds a config option that allows ignoring specific modules for `eqwalize-all`.

I think it would be nice to also allow some form of patterns (regex or shell-style globs) in addition to plain module names, e.g.
```
[eqwalizer]
ignore_modules = ["some_module", "some_app_*_pb"]
```
Q: Would patterns also be acceptable or does that violate some project rules or conventions?

Closes #67