### PR TITLE
fix: including based on an application path requires include_lib

### DIFF
--- a/website/docs/erlang-error-index/w/W0037.md
+++ b/website/docs/erlang-error-index/w/W0037.md
@@ -14,7 +14,7 @@ sidebar_position: 37
 becomes
 
 ```erlang
--include("app_a/include/some_header_from_app_a.hrl").
+-include_lib("app_a/include/some_header_from_app_a.hrl").
 ```
 
 ## Explanation


### PR DESCRIPTION
`include` will only treat the given string as a path while `include_lib` parses out `app_a` and looks in the library directory of that application