### PR TITLE
Allow project discovery for OTP

### DIFF
--- a/crates/elp/src/project_loader.rs
+++ b/crates/elp/src/project_loader.rs
@@ -101,7 +101,14 @@ impl ProjectLoader {
         let mut path_it = path;
         loop {
             if self.project_roots.contains_key(path_it) {
-                return None;
+                match self.project_roots.get(path_it) {
+                    Some(None) => {
+                        return Some(self.load_manifest(path_it));
+                    }
+                    _ => {
+                        return None;
+                    }
+                }
             }
             match path_it.parent() {
                 Some(parent) => path_it = parent,


### PR DESCRIPTION
Some clients, such as emacs eglot, do their own project discovery when a new file is opened, even from the target of a go to definition.

They then launch a fresh ELP server if they determine a different project root.

In the ELP server setup we preconfigure the OTP project root as known, but with a project manifest of None. This means go to def into an OTP file ends up with an uninitialized project in the new server.

This diff makes it so that if the project root is known, but has no project manifest, we do discovery on that root.