### PR TITLE
Canonicalize project_path() in OSS test builds

### DIFF
--- a/crates/elp/src/bin/test_utils.rs
+++ b/crates/elp/src/bin/test_utils.rs
@@ -50,7 +50,18 @@ pub fn project_path(project: &str) -> String {
 
     #[cfg(not(buck_build))]
     {
-        format!("../../test/test_projects/{project}")
+        let project_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test/test_projects")
+            .join(project);
+        dunce::canonicalize(&project_path)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Failed to canonicalize project path: {}",
+                    project_path.display()
+                )
+            })
+            .to_string_lossy()
+            .to_string()
     }
 }
 


### PR DESCRIPTION
Summary:
`lint_config_file_parse_error` fails on GitHub (OSS/Cargo) while passing at Meta (Buck). D108603716 anchored `.elp_lint.toml` discovery at the project root returned by `load::discover_manifest`, which canonicalizes the path via `dunce::canonicalize`. The CLI test normalizes output by replacing the `--project` value (from `test_utils::project_path()`) with `{project_path}`. Under `#[cfg(buck_build)]`, `project_path()` already returns a canonicalized absolute path, so the substitution matches. Under `#[cfg(not(buck_build))]` it returned a relative path (`../../test/test_projects/<p>`), which is no longer a substring of ELP's now-absolute reported path, so normalization stops firing and the snapshot mismatches.

This makes the OSS arm canonicalize too, mirroring the `buck_build` arm and the sibling `get_resources_dir()`. It builds the path from `CARGO_MANIFEST_DIR` (so it does not depend on the test's current working directory) and runs it through `dunce::canonicalize` — the same call ELP uses during discovery — so the value matches ELP's output exactly. No committed snapshot embeds a literal relative path (all use the `{project_path}` placeholder), so snapshot contents are unchanged.

Differential Revision: D108760333


