### PR TITLE
ELP: regenerate resource_file! snapshots under Buck via update-expect (#222)

### DIFF
--- a/crates/elp/src/bin/test_utils.rs
+++ b/crates/elp/src/bin/test_utils.rs
@@ -10,18 +10,9 @@
 
 use std::path::PathBuf;
 
-#[cfg(buck_build)]
-pub fn get_resources_dir() -> PathBuf {
-    let resource_path = buck_resources::get("whatsapp/elp/crates/elp/test_resources")
-        .unwrap()
-        .join("src/resources/test");
-    dunce::canonicalize(&resource_path).unwrap_or_else(|_| {
-        panic!(
-            "Failed to canonicalize resources path: {}",
-            resource_path.display()
-        )
-    })
-}
+// @fb-only: #[rustfmt::skip]
+// @fb-only: #[cfg(buck_build)]
+// @fb-only: pub fn get_resources_dir() -> PathBuf { crate::meta_only::get_resources_dir() }
 
 #[cfg(not(buck_build))]
 pub fn get_resources_dir() -> PathBuf {


### PR DESCRIPTION
Summary:

The `.stdout`/`.jsonl`/etc. snapshots referenced by `resource_file!(...)` in `crates/elp/src/bin/main.rs` could not be regenerated by the `:elp-update-expect` flow under Buck. Under `buck_build`, `get_resources_dir()` resolved to the read-only `buck-out` sandbox copy via `buck_resources::get(...)`, so `expect_file!` writes never reached the source tree — these snapshots had to be updated by hand.

This mirrors the existing `CARGO_WORKSPACE_DIR` redirect used for inline `expect![[...]]` snapshots. `get_resources_dir()` now checks `CARGO_WORKSPACE_DIR` at runtime (set by `scripts/update_expect.sh`, which the `:elp-update-expect` wrapper invokes): when present, non-empty, and not `"__UNUSED__"`, it returns the checked-in path. Normal test runs are unaffected and fall back to `buck_resources::get(...)`.

Usage:
`buck2 run //whatsapp/elp/crates/elp:elp-update-expect -- <test_filter>`

Reviewed By: michalmuskala

Differential Revision: D108604287


