### PR TITLE
Add 29 pipeline, drop 26 (#225)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,20 +31,20 @@ jobs:
       fail-fast: false
       matrix:
         platform-arch: [ubuntu-22.04-x64, ubuntu-22.04-arm, macos-15-x64, macos-latest-arm, windows-2022-x64]
-        otp-version: [26.2, 27.3, 28.0]
+        otp-version: [27.3, 28.5, 29.0]
         include:
-          - otp-version: 26.2
-            brew-otp-version: 26
-            vscode-publish: true
-            choco-otp-version: 26.2.5.13
           - otp-version: 27.3
             brew-otp-version: 27
-            vscode-publish: false
+            vscode-publish: true
             choco-otp-version: 27.3.4
-          - otp-version: 28.0
+          - otp-version: 28.5
             brew-otp-version: 28
             vscode-publish: false
-            choco-otp-version: 28.0.1
+            choco-otp-version: 28.5.0
+          - otp-version: 29.0
+            brew-otp-version: 29
+            vscode-publish: false
+            choco-otp-version: 29.0.2
           - platform-arch: ubuntu-22.04-x64
             platform: ubuntu-22.04
             os: linux

--- a/crates/eqwalizer/src/ast/convert.rs
+++ b/crates/eqwalizer/src/ast/convert.rs
@@ -1931,6 +1931,12 @@ impl Converter {
                     _ => (),
                 },
                 ("type", [Term::Atom(kind), Term::List(decl)]) if kind.name == "record" => {
+                    if decl.elements.is_empty() {
+                        // TODO(T275607429): Properly handle native records in ELP
+                        // Until native records are properly supported, model it
+                        // as dynamic().
+                        return Ok(ExtType::dynamic_ext_type(pos));
+                    }
                     if let [record_name, field_tys @ ..] = &decl.elements[..] {
                         let record_name = self.convert_atom_lit(record_name)?;
                         if field_tys.is_empty() {


### PR DESCRIPTION
Summary:

Erlang/OTP 29 was released in May 2026. Let's add a pipeline for the new version and drop the oldest OTP 26 pipeline.
The VS Code extension is updated to bundle the Erlang/OTP 27 built version of ELP.

Reviewed By: alanz

Differential Revision: D109301472


