### PR TITLE
Support OTP 29 `record()` predefined type in eqwalizer converter

### DIFF
--- a/crates/eqwalizer/src/ast/convert.rs
+++ b/crates/eqwalizer/src/ast/convert.rs
@@ -1931,6 +1931,10 @@ impl Converter {
                     _ => (),
                 },
                 ("type", [Term::Atom(kind), Term::List(decl)]) if kind.name == "record" => {
+                    if decl.elements.is_empty() {
+                        // OTP 29 predefined `record()` type (any record); a record is a tuple
+                        return Ok(ExtType::tuple_ext_type(pos));
+                    }
                     if let [record_name, field_tys @ ..] = &decl.elements[..] {
                         let record_name = self.convert_atom_lit(record_name)?;
                         if field_tys.is_empty() {


### PR DESCRIPTION
Summary:
OTP 29 adds a new predefined type `record()` (meaning "any record") to the `erlang` module, analogous to `tuple()` and `map()`. Its abstract form is `{type, Anno, record, []}` — a `record` type node with an empty argument list, since there is no specific record name.

eqWAlizer's EETF-to-type converter (`convert_type` in `crates/eqwalizer/src/ast/convert.rs`) only matched a `record` type when the argument list was non-empty (it expected at least the record name). The empty-argument form fell through to the catch-all and returned `ConversionError::InvalidType`. Because eqWAlizer always loads and converts the `erlang` module, this single unconvertible form aborted the entire eqwalize run with exit code 101 on OTP 29, before any diagnostics were produced — every `eqwalize*` command was affected.

The fix maps the empty-argument `record()` form to `tuple()`, which is the correct supertype: every record is a tuple.

Differential Revision: D109593870


