### PR TITLE
Update READMEs for eqWAlizer move into ELP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./logo/elp_final_Full_Logo_White_Text.png">
-  <img alt="ELP logo" src="./logo/elp_final_Full_Logo_Color.png" width="100%">
+  <img alt="ELP logo" src="./logo/elp_final_Full_Logo_Color.png" width="60%">
 </picture>
 
 ## Description
@@ -18,6 +18,15 @@ references, call hierarchy and more for your IDE of choice.
 
 ELP is easily **extensible** and provides a convenient **API to implement
 linters and refactoring tools for Erlang**.
+
+ELP also includes **eqWAlizer**, a type-checker for Erlang. eqWAlizer brings
+static type-checking to Erlang code, helping you catch type errors before they
+reach production. See the [eqWAlizer README](./eqwalizer/README.md) for details.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./eqwalizer/logo/eqWAlizer_final_Full_Logo_White_Text.png">
+  <img alt="eqWAlizer logo" src="./eqwalizer/logo/eqWAlizer_final_Full__Logo_Black_Text.png" width="30%">
+</picture>
 
 ## Terms of Use
 

--- a/eqwalizer/README.md
+++ b/eqwalizer/README.md
@@ -2,6 +2,10 @@
 
 A type-checker for Erlang.
 
+> [!IMPORTANT]
+> The eqWAlizer repository is moving into [ELP (Erlang Language Platform)](https://github.com/whatsapp/erlang-language-platform).
+> Please use the [erlang-language-platform](https://github.com/whatsapp/erlang-language-platform) repository for issues and pull requests.
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./logo/eqWAlizer_final_Full_Logo_White_Text.png">
   <img alt="eqWAlizer logo" src="./logo/eqWAlizer_final_Full__Logo_Black_Text.png" width="100%">
@@ -26,9 +30,9 @@ Adding `eqwalizer_support`:
 {deps, [
   {eqwalizer_support,
     {git_subdir,
-        "https://github.com/whatsapp/eqwalizer.git",
+        "https://github.com/whatsapp/erlang-language-platform.git",
         {branch, "main"},
-        "eqwalizer_support"}}
+        "eqwalizer/eqwalizer_support"}}
 ]}.
 ```
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/WhatsApp/eqwalizer/pull/81

The eqWAlizer repository is moving into the ELP (Erlang Language Platform) repository. This updates the relevant documentation:

- `eqwalizer/README.md`: Update the `eqwalizer_support` dependency snippet to point at `https://github.com/whatsapp/erlang-language-platform.git` with the `eqwalizer/eqwalizer_support` subdir, and add an `[!IMPORTANT]` admonition at the top directing issues and pull requests to the `erlang-language-platform` repository.
- `elp/README.md`: Expand the description to explain that ELP includes eqWAlizer (with a one-line summary of what it is) and link to the eqWAlizer README, add a small eqWAlizer logo, and shrink the ELP logo to render at 60% width.

Differential Revision: D109806596


