### PR TITLE
[ELP/OSS] Add permissions to GitHub workflows

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+# Restrict the default GITHUB_TOKEN: this workflow only builds the website.
+permissions:
+  contents: read
+
 jobs:
   build-website:
     name: Build Website

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [published]
 
+# Restrict the default GITHUB_TOKEN. Jobs needing more override this below.
+permissions:
+  contents: read
+
 jobs:
   edb:
     runs-on: ubuntu-latest
@@ -27,6 +31,9 @@ jobs:
           otp-version: ${{ matrix.otp-version}}
 
   ci:
+    # Release runs attach binaries and the .vsix to the GitHub release.
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
 
+# Restrict the default GITHUB_TOKEN. actions-gh-pages pushes the built site to
+# the gh-pages branch, so contents: write is required.
+permissions:
+  contents: write
+
 jobs:
   deploy-website:
     name: Deploy Website to GitHub Pages


### PR DESCRIPTION
Fixes CodeQL `actions/missing-workflow-permissions` alerts #2, #3, #4 and #6 (medium). Without an explicit `permissions` block a job inherits the repo/org default for GITHUB_TOKEN, which for repos created before February 2023 is read-write. Declaring permissions documents what each job actually needs and keeps them restricted if the default changes or a workflow is copied elsewhere.

Permissions are derived from what each job does:

- build-website.yml: `contents: read`. PR-only build, no token use.
- ci.yml: root `contents: read`, with the `ci` job overriding to `contents: write`. The `edb` job only checks out this repo plus the public WhatsApp/edb and uploads an artifact -- upload-artifact@v4 authenticates with ACTIONS_RUNTIME_TOKEN rather than GITHUB_TOKEN, so read suffices. The `ci` job runs bruceadams/get-release and actions/upload-release-asset on `release` events, which need write.
- deploy-website.yml: `contents: write`, as peaceiris/actions-gh-pages pushes the built site to the gh-pages branch using GITHUB_TOKEN.

Note that GitHub has no per-event permissions, so the `ci` job carries `contents: write` on push and pull_request runs as well, not only on releases. Fork PRs still receive a read-only token regardless. Tightening this further would mean splitting release publishing into its own job gated on `github.event_name == 'release'`.