### PR TITLE
CI: make release asset uploads idempotent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,28 +218,24 @@ jobs:
         with:
           name: eqwalizer-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}
           path: .\eqwalizer\eqwalizer\eqwalizer.exe
-      - name: Make elp-${{ matrix.os }}-otp-${{ matrix.otp-version }}.tar.gz (No Windows)
+      # The tarball is named after the release asset it becomes: the upload
+      # action names each asset after the file's basename.
+      - name: Make elp-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.tar.gz (No Windows)
         if: matrix.os != 'windows'
-        run: 'tar -zcvf elp-${{ matrix.os }}-otp-${{ matrix.otp-version }}.tar.gz -C target/${{ matrix.target}}/release/ elp'
-      - name: Make elp-${{ matrix.os }}-otp-${{ matrix.otp-version }}.tar.gz (Windows Only)
+        run: 'tar -zcvf elp-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.tar.gz -C target/${{ matrix.target}}/release/ elp'
+      - name: Make elp-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.tar.gz (Windows Only)
         if: matrix.os == 'windows'
-        run: 'tar -zcvf elp-${{ matrix.os }}-otp-${{ matrix.otp-version }}.tar.gz -C target\${{ matrix.target}}\release elp.exe'
-      - env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        id: get_release_url
-        name: Get release url
+        run: 'tar -zcvf elp-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.tar.gz -C target\${{ matrix.target}}\release elp.exe'
+      # `overwrite_files` (the default) replaces an asset that is already
+      # attached, so re-running a release workflow does not die here the way
+      # actions/upload-release-asset did with a 422 Validation Failed.
+      - name: Upload release elp-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.tar.gz
         if: ${{ github.event_name == 'release' }}
-        uses: "bruceadams/get-release@v1.3.2"
-      - env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        name: Upload release elp-${{ matrix.os }}-otp-${{ matrix.otp-version }}.tar.gz
-        if: ${{ github.event_name == 'release' }}
-        uses: "actions/upload-release-asset@v1.0.2"
+        uses: "softprops/action-gh-release@v2"
         with:
-          asset_content_type: application/octet-stream
-          asset_name: elp-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.tar.gz
-          asset_path: elp-${{ matrix.os }}-otp-${{ matrix.otp-version }}.tar.gz
-          upload_url: "${{ steps.get_release_url.outputs.upload_url }}"
+          tag_name: ${{ github.event.release.tag_name }}
+          files: elp-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.tar.gz
+          fail_on_unmatched_files: true
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -309,26 +305,21 @@ jobs:
         with:
           name: elp-${{ matrix.os}}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.vsix
           path: editors\code\erlang-language-platform.vsix
-      - env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        name: Upload Extension Package (No Windows)
-        if: ${{ github.event_name == 'release' && matrix.os != 'windows' }}
-        uses: "actions/upload-release-asset@v1.0.2"
+      # The asset is named after the file's basename, and
+      # erlang-language-platform.vsix keeps its name for the vsce/ovsx publish
+      # steps below, so copy it to the asset name rather than renaming it.
+      - name: Copy Extension Package to its release asset name
+        if: ${{ github.event_name == 'release' }}
+        working-directory: editors/code
+        shell: bash
+        run: 'cp erlang-language-platform.vsix elp-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.vsix'
+      - name: Upload Extension Package
+        if: ${{ github.event_name == 'release' }}
+        uses: "softprops/action-gh-release@v2"
         with:
-          asset_content_type: application/octet-stream
-          asset_name: elp-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.vsix
-          asset_path: editors/code/erlang-language-platform.vsix
-          upload_url: "${{ steps.get_release_url.outputs.upload_url }}"
-      - env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        name: Upload Extension Package (Windows Only)
-        if: ${{ github.event_name == 'release' && matrix.os == 'windows' }}
-        uses: "actions/upload-release-asset@v1.0.2"
-        with:
-          asset_content_type: application/octet-stream
-          asset_name: elp-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.vsix
-          asset_path: editors\code\erlang-language-platform.vsix
-          upload_url: "${{ steps.get_release_url.outputs.upload_url }}"
+          tag_name: ${{ github.event.release.tag_name }}
+          files: editors/code/elp-${{ matrix.os }}-${{ matrix.target }}-otp-${{ matrix.otp-version }}.vsix
+          fail_on_unmatched_files: true
       - name: Publish extension to marketplace
         working-directory: editors/code
         if: ${{ github.event_name == 'release' && matrix.vscode-publish && matrix.os != 'windows' }}


### PR DESCRIPTION
## Summary

`actions/upload-release-asset@v1.0.2` returns a 422 `Validation Failed` if an asset of that name is already attached to the release, so re-running a release workflow always dies at the first upload step instead of reaching the steps that actually failed.

That is what happened on [run 31182621245](https://github.com/WhatsApp/erlang-language-platform/actions/runs/31182621245) for the `2026-08-07` release:

- **Attempt 1** uploaded all 30 assets successfully, then four jobs (the `otp-27.3` non-Windows matrix entries, i.e. the `vscode-publish: true` ones) failed at `Publish extension to marketplace`:
  ```
  Access Denied: The Personal Access Token used has expired.
  ```
- **Attempt 2** (the re-run) never got that far — it failed at `Upload release elp-linux-otp-27.3.tar.gz` with `Validation Failed`, because attempt 1 had already attached that asset.

The `contents: write` added in 160fafc4fd is sufficient; neither failure is a `GITHUB_TOKEN` permissions problem.

## Change

Replace `actions/upload-release-asset@v1.0.2`, and the `bruceadams/get-release@v1.3.2` step that existed only to supply its `upload_url`, with `softprops/action-gh-release@v2`. Its `overwrite_files` input defaults to true, so an asset that is already attached is replaced rather than rejected with a 422 — which is what makes a re-run idempotent. The action resolves the release itself from `tag_name: ${{ github.event.release.tag_name }}`, so the separate release-lookup step is no longer needed, and it authenticates with the job's existing `contents: write` `GITHUB_TOKEN`. `actions/upload-release-asset` is also no longer maintained.

`fail_on_unmatched_files: true` is set on both uploads, so a missing artifact fails the job instead of silently publishing an incomplete release.

The action names each asset after the file's basename, so:

- the tarball is now built under its final asset name (`elp-<os>-<target>-otp-<version>.tar.gz`) rather than being renamed at upload time;
- the `.vsix` is copied to its asset name before upload — `erlang-language-platform.vsix` has to keep its name for the `vsce`/`ovsx` publish steps that follow.

Since the upload step no longer takes a per-OS `asset_path`, the `Upload Extension Package` No-Windows/Windows-Only pair collapses into one upload step preceded by a single `shell: bash` copy step. The `Make ...tar.gz` pair stays split, because the `tar -C` paths differ by separator.

**The published asset names are unchanged**, so the download URLs in `website/docs/get-started/install.md` still resolve.

## Not fixed here

The expired `VSCE_PAT` secret needs rotating separately — a new Azure DevOps PAT with the Marketplace → Manage scope. `OVSX_PAT` was never reached, so its state is unknown and worth checking at the same time.

## Test plan

Not exercisable outside a real `release` event. Verified locally that the workflow YAML parses and step ordering is unchanged; the upload steps are guarded by `github.event_name == 'release'`, so push/PR runs are unaffected by this change.